### PR TITLE
data_df_reset -> data_df 변수명 수정

### DIFF
--- a/1장/1.4 데이터 핸들링 - 판다스.ipynb
+++ b/1장/1.4 데이터 핸들링 - 판다스.ipynb
@@ -522,7 +522,7 @@
    "outputs": [],
    "source": [
     "# 아래 코드는 오류를 발생합니다. \n",
-    "data_df_reset.loc[0, 'Name']"
+    "data_df.loc[0, 'Name']"
    ]
   },
   {


### PR DESCRIPTION
위에서는 data_df 변수를 사용하다가 수정 전 부분에서는 data_df_reset변수를 사용하고 있습니다. 그래서 data_df로 변수명 수정하였습니다.